### PR TITLE
successfully check the exension of the current opened file in workspace

### DIFF
--- a/autoblade/package.json
+++ b/autoblade/package.json
@@ -14,7 +14,7 @@
   "contributes": {
     "commands": [
       {
-        "command": "autoblade.helloWorld",
+        "command": "autoblade.start",
         "title": "Auto Blade"
       }
     ]

--- a/autoblade/src/extension.ts
+++ b/autoblade/src/extension.ts
@@ -1,26 +1,41 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "autoblade" is now active!');
+  console.log('Congratulations, your extension "autoblade" is now active!');
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('autoblade.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from autoBlade!');
-	});
+  // The command has been defined in the package.json file
+  // Now provide the implementation of the command with registerCommand
+  // The commandId parameter must match the command field in package.json
+  const disposable = vscode.commands.registerCommand("autoblade.start", () => {
+    // vscode.window.showInformationMessage("Hello World from autoBlade!");
 
-	context.subscriptions.push(disposable);
+    isHtml()
+      ? vscode.window.showInformationMessage("The current opened file is html")
+      : vscode.window.showErrorMessage("The current File must be html");
+  });
+
+  context.subscriptions.push(disposable);
 }
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
+
+/**
+ * Check if the current opened file has .html extension
+ * @returns {boolean} True if the file has a .html extension, false otherwise.
+ */
+
+function isHtml(): boolean {
+  const editor = vscode.window.activeTextEditor;
+
+  if (editor) {
+    const document = editor.document;
+    const fileName = document.fileName;
+    return fileName.endsWith(".html");
+  }
+
+  return false;
+}


### PR DESCRIPTION
Implemented #1 

Just added a function that use Vscode Namespace 'Windows' and active textEditor to get the current opened file and check if it has `.html` extension. Seems to wirok successfully